### PR TITLE
Fix main thread/background thread issue.

### DIFF
--- a/athmovil-checkout/Source/ATHMCheckout.swift
+++ b/athmovil-checkout/Source/ATHMCheckout.swift
@@ -255,6 +255,8 @@ public enum AMErrorType: String, Error {
             "?transaction_data=\(jsonString)") else { throw AMErrorType.malformedURLException }
 
         let urlOpener = URLOpener(application: UIApplication.shared)
-        urlOpener.openWebsite(url: backURL, alternateURL: appStoreURL, completion: nil)
+        DispatchQueue.main.async {
+          urlOpener.openWebsite(url: backURL, alternateURL: appStoreURL, completion: nil)
+        }
     }
 }


### PR DESCRIPTION
Fix warning thrown by main thread checker around opening URL in background thread, by queuing up opening of website in main thread.

```
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIApplication openURL:options:completionHandler:]
PID: 3556, TID: 1127479, Thread name: (none), Queue name: com.facebook.react.ATHMovilQueue, QoS: 0
Backtrace:
4   miprepay                            0x00000001029fd298 $s17athmovil_checkout9URLOpenerV11openWebsite3url12alternateURL10completiony10Foundation0H0V_AJySbcSgtF + 732
5   miprepay                            0x00000001029e87dc $s17athmovil_checkout12ATHMCheckoutC0B04withyAA11ATHMPaymentC_tKF + 2244
6   miprepay                            0x00000001029e8bb8 $s17athmovil_checkout12ATHMCheckoutC0B04withyAA11ATHMPaymentC_tKFTo + 112
7   miprepay                            0x0000000102613544 -[AthMovilModule _pay:total:subtotal:tax:metadata1:metadata2:items:] + 564
8   miprepay                            0x0000000102613f8c -[AthMovilModule pay:publicToken:total:subtotal:tax:metadata1:metadata2:items:isProd:errorFn:] + 356
```

This issue sometimes causes ATHMovil to take 1-10 seconds to load up with a requested transaction.