### PR TITLE
Change Universal Links to URLSchemes

### DIFF
--- a/athmovil-checkout/Source/ATHMPaymentRequest.swift
+++ b/athmovil-checkout/Source/ATHMPaymentRequest.swift
@@ -104,14 +104,14 @@ extension ATHMPaymentRequest {
                 let paymentSender = AnyPaymentSender(paymentRequest: self,
                                                      paymentHandler: handler,
                                                      paymentOpener: urlopener)
-                paymentSender.sendPayment(target: TargetUniversalLinks.athMovil, session: .shared)
+                paymentSender.sendPayment(target: TargetURLScheme.athMovil, session: .shared)
                 
             default:
                 let paymentSimulated = PaymentSimulated(paymentRequest: self)
                 let paymentSender = AnyPaymentSender(paymentRequest: paymentSimulated,
                                                      paymentHandler: handler,
                                                      paymentOpener: urlopener)
-                paymentSender.sendPayment(target: TargetUniversalLinks.athMovilSimulated, session: .shared)
+                paymentSender.sendPayment(target: TargetURLScheme.athMovilSimulated, session: .shared)
         }
     }
 }


### PR DESCRIPTION
The universal links being used by the SDK is broken and apps are trying to open ATH Móvil on the iTunes Store app. Moving to URLSchemes fixes issue #13.